### PR TITLE
[PSEC-1343] Add config options for Athena client throttling

### DIFF
--- a/aws_scanner_config_template.ini
+++ b/aws_scanner_config_template.ini
@@ -3,7 +3,9 @@ account = 555666777888
 role = athena_role
 database_prefix = some_prefix
 query_results_bucket = query-results-bucket
-run_query_timeout = 1200
+query_results_polling_delay_seconds = 1
+query_timeout_seconds = 1200
+query_throttling_seconds = 2
 
 [cloudtrail]
 logs_bucket = cloudtrail-logs-bucket

--- a/aws_scanner_test_config.ini
+++ b/aws_scanner_test_config.ini
@@ -3,7 +3,9 @@ account = 555666777888
 role = athena_role
 database_prefix = some_prefix
 query_results_bucket = query-results-bucket
-run_query_timeout = 1200
+query_results_polling_delay_seconds = 0
+query_timeout_seconds = 1200
+query_throttling_seconds = 0
 
 [cost_explorer]
 role = cost_explorer_role

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,9 @@ account = 555666777888
 role = athena_role
 database_prefix = some_prefix
 query_results_bucket = query-results-bucket
-run_query_timeout = 666
+query_results_polling_delay_seconds = 1
+query_timeout_seconds = 600
+query_throttling_seconds = 2
 ```
 
 -   `account`: an account where [CloudTrail logs][aws-cloudtrail] of other AWS accounts are centrally collected
@@ -26,7 +28,11 @@ run_query_timeout = 666
 
 -   `query_results_bucket`: name of the bucket were results of [Athena queries][aws-athena-querying] will be stored
 
--   `run_query_timeout`: set the max duration the Athena query runs for
+-   `query_results_polling_delay_seconds`: interval between two query results polls
+
+-   `query_timeout_seconds`: maximum duration a query can run for
+
+-   `query_throttling_seconds`: delay before starting a new query execution
 
 ## CloudTrail
 

--- a/src/aws_scanner_config.py
+++ b/src/aws_scanner_config.py
@@ -27,8 +27,14 @@ class AwsScannerConfig:
     def athena_query_results_bucket(self) -> str:
         return self._get_config("athena", "query_results_bucket")
 
-    def athena_run_query_timeout(self) -> int:
-        return int(self._get_config("athena", "run_query_timeout"))
+    def athena_query_timeout_seconds(self) -> int:
+        return int(self._get_config("athena", "query_timeout_seconds"))
+
+    def athena_query_results_polling_delay_seconds(self) -> int:
+        return int(self._get_config("athena", "query_results_polling_delay_seconds"))
+
+    def athena_query_throttling_seconds(self) -> int:
+        return int(self._get_config("athena", "query_throttling_seconds"))
 
     def cloudtrail_logs_bucket(self) -> str:
         return self._get_config("cloudtrail", "logs_bucket")

--- a/tests/clients/test_aws_athena_client.py
+++ b/tests/clients/test_aws_athena_client.py
@@ -9,9 +9,8 @@ from src.clients.aws_athena_client import AwsAthenaClient
 from tests.test_types_generator import account, partition
 
 
-@patch.object(AwsAthenaClient, "_get_default_delay", return_value=0)
 class TestWaitFor(TestCase):
-    def test_wait_for_completion(self, _: Mock) -> None:
+    def test_wait_for_completion(self) -> None:
         query_id = "8759-2768-2364"
         mock_has_query_completed = Mock(side_effect=[False, False, True])
         with patch(
@@ -20,7 +19,7 @@ class TestWaitFor(TestCase):
             AwsAthenaClient(Mock())._wait_for_completion(query_id, 60)
         mock_has_query_completed.assert_has_calls([call(query_id) for _ in range(3)])
 
-    def test_wait_for_completion_timeout(self, _: Mock) -> None:
+    def test_wait_for_completion_timeout(self) -> None:
         query_id = "9837-4857-3576"
         mock_has_query_completed = Mock(return_value=False)
         with patch(
@@ -31,7 +30,7 @@ class TestWaitFor(TestCase):
         mock_has_query_completed.assert_has_calls([call(query_id) for _ in range(30)])
         self.assertIn(query_id, ex.exception.args[0])
 
-    def test_wait_for_success(self, _: Mock) -> None:
+    def test_wait_for_success(self) -> None:
         query_id = "9847-2919-2284"
         timeout = 74
         query_results = ["some results"]
@@ -50,7 +49,7 @@ class TestWaitFor(TestCase):
         mock_wait_for_completion.assert_called_once_with(query_id, timeout)
         mock_query_succeeded.assert_called_once_with(query_id)
 
-    def test_wait_for_success_query_does_not_succeed(self, _: Mock) -> None:
+    def test_wait_for_success_query_does_not_succeed(self) -> None:
         mock_wait_for_completion = Mock(return_value=None)
         mock_query_succeeded = Mock(return_value=False)
         query_error = "the query failed for some reasons"
@@ -74,7 +73,7 @@ class TestQueries(TestCase):
             mock_wait_for_success=mock_wait_for_success,
             method_under_test="create_database",
             method_args={"database_name": "some_db_name"},
-            timeout_seconds=60,
+            timeout_seconds=1200,
             raise_on_failure=exceptions.CreateDatabaseException,
         )
 
@@ -83,7 +82,7 @@ class TestQueries(TestCase):
             mock_wait_for_success=mock_wait_for_success,
             method_under_test="drop_database",
             method_args={"database_name": "some_db_name"},
-            timeout_seconds=60,
+            timeout_seconds=1200,
             raise_on_failure=exceptions.DropDatabaseException,
         )
 
@@ -92,7 +91,7 @@ class TestQueries(TestCase):
             mock_wait_for_success=mock_wait_for_success,
             method_under_test="create_table",
             method_args={"database": "some_db", "account": account()},
-            timeout_seconds=60,
+            timeout_seconds=1200,
             raise_on_failure=exceptions.CreateTableException,
         )
 
@@ -101,7 +100,7 @@ class TestQueries(TestCase):
             mock_wait_for_success=mock_wait_for_success,
             method_under_test="drop_table",
             method_args={"database": "some_db", "table": "some_account_id"},
-            timeout_seconds=60,
+            timeout_seconds=1200,
             raise_on_failure=exceptions.DropTableException,
         )
 
@@ -114,7 +113,7 @@ class TestQueries(TestCase):
                 "account": account(),
                 "partition": partition(2020, 8),
             },
-            timeout_seconds=120,
+            timeout_seconds=1200,
             raise_on_failure=exceptions.AddPartitionException,
         )
 
@@ -151,11 +150,6 @@ class TestQueries(TestCase):
         )
         if return_results:
             self.assertEqual(query_results, actual_results)
-
-
-class TestDefaultDelay(TestCase):
-    def test_default_delay_is_one_second(self) -> None:
-        self.assertEqual(1, AwsAthenaClient(Mock())._get_default_delay())
 
 
 class TestList(TestCase):

--- a/tests/test_aws_scanner_config.py
+++ b/tests/test_aws_scanner_config.py
@@ -17,7 +17,9 @@ def test_init_config_from_file() -> None:
     assert "some_prefix" == config.athena_database_prefix()
     assert "query-results-bucket" == config.athena_query_results_bucket()
     assert "cloudtrail-logs-bucket" == config.cloudtrail_logs_bucket()
-    assert 1200 == config.athena_run_query_timeout()
+    assert 0 == config.athena_query_results_polling_delay_seconds()
+    assert 1200 == config.athena_query_timeout_seconds()
+    assert 0 == config.athena_query_throttling_seconds()
     assert 90 == config.cloudtrail_logs_retention_days()
     assert "ec2_role" == config.ec2_role()
     assert "ACTIVE" == config.ec2_flow_log_status()
@@ -64,7 +66,9 @@ def test_init_config_from_file() -> None:
         "AWS_SCANNER_ATHENA_ROLE": "the_athena_role",
         "AWS_SCANNER_ATHENA_DATABASE_PREFIX": "a_db_prefix",
         "AWS_SCANNER_ATHENA_QUERY_RESULTS_BUCKET": "a-query-results-bucket",
-        "AWS_SCANNER_ATHENA_RUN_QUERY_TIMEOUT": "900",
+        "AWS_SCANNER_ATHENA_QUERY_RESULTS_POLLING_DELAY_SECONDS": "2",
+        "AWS_SCANNER_ATHENA_QUERY_TIMEOUT_SECONDS": "900",
+        "AWS_SCANNER_ATHENA_QUERY_THROTTLING_SECONDS": "3",
         "AWS_SCANNER_CLOUDTRAIL_LOGS_BUCKET": "a-cloudtrail-logs-bucket",
         "AWS_SCANNER_CLOUDTRAIL_LOGS_RETENTION_DAYS": "30",
         "AWS_SCANNER_EC2_ROLE": "the_ec2_role",
@@ -106,7 +110,9 @@ def test_init_config_from_env_vars() -> None:
     assert "the_athena_role" == config.athena_role()
     assert "a_db_prefix" == config.athena_database_prefix()
     assert "a-query-results-bucket" == config.athena_query_results_bucket()
-    assert 900 == config.athena_run_query_timeout()
+    assert 2 == config.athena_query_results_polling_delay_seconds()
+    assert 900 == config.athena_query_timeout_seconds()
+    assert 3 == config.athena_query_throttling_seconds()
     assert "a-cloudtrail-logs-bucket" == config.cloudtrail_logs_bucket()
     assert 30 == config.cloudtrail_logs_retention_days()
     assert "the_ec2_role" == config.ec2_role()


### PR DESCRIPTION
Default Athena limits can easily be exhausted when running multiple scanning tasks concurrently. Quotas can be increased (see https://docs.aws.amazon.com/athena/latest/ug/service-limits.html), but the additional config options brought by this commit should help in the meantime.