### PR TITLE
PSEC-1105

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ifdef CI_MODE
 		--build-arg PIP_PIPENV_VERSION=$(PIP_PIPENV_VERSION) \
 		&& docker run test-run:ci
 else
-	DOCKER = @docker build \
+	DOCKER = docker build \
 		--file Dockerfile \
                 --build-arg PYTHON_VERSION=$(PYTHON_VERSION) \
                 --build-arg PIP_PIPENV_VERSION=$(PIP_PIPENV_VERSION) \
@@ -19,7 +19,6 @@ else
                 --build-arg "home=${HOME}" \
                 --build-arg "workdir=${PWD}" \
 		--tag test-run:local . \
-		> /dev/null \
 		&& docker run \
 		--interactive \
 		--rm \
@@ -61,7 +60,7 @@ python-test:
 		tests
 
 md-check:
-	@docker pull zemanlx/remark-lint:0.2.0 > /dev/null
+	@docker pull zemanlx/remark-lint:0.2.0
 	@docker run --rm -i -v $(PWD):/lint/input:ro zemanlx/remark-lint:0.2.0 --frail .
 
 container-release:

--- a/platsec_aws_scanner.sh
+++ b/platsec_aws_scanner.sh
@@ -32,5 +32,4 @@ docker run \
   --env AWS_SECRET_ACCESS_KEY \
   --env AWS_SESSION_TOKEN \
   --env AWS_SECURITY_TOKEN \
-  "$IMAGE_TAG" "$@" \
-  | jq
+  "$IMAGE_TAG" "$@"

--- a/src/aws_parallel_task_runner.py
+++ b/src/aws_parallel_task_runner.py
@@ -20,5 +20,5 @@ class AwsParallelTaskRunner(AwsTaskRunner):
         try:
             return future.result()
         except AwsScannerException as ex:
-            self._logger.error(f"{all_futures[future]} failed with: '{ex}'")
+            self._logger.error(f"{all_futures[future]} failed with: '{type(ex).__name__}: {ex}'")
         return None

--- a/src/aws_scanner_argument_parser.py
+++ b/src/aws_scanner_argument_parser.py
@@ -37,6 +37,7 @@ class AwsScannerCommands:
     list_ssm_parameters: str = "list_ssm_parameters"
     drop: str = "drop"
     audit_s3: str = "audit_s3"
+    audit_iam: str = "audit_iam"
     audit_vpc_flow_logs: str = "audit_vpc_flow_logs"
     cost_explorer: str = "cost_explorer"
 
@@ -106,6 +107,7 @@ class AwsScannerArgumentParser:
         self._add_create_table_command(subparsers)
         self._add_drop_command(subparsers)
         self._add_audit_s3_command(subparsers)
+        self._add_audit_iam_command(subparsers)
         self._add_audit_vpc_flow_logs_command(subparsers)
         self._add_cost_explorer_command(subparsers)
         return parser
@@ -119,6 +121,13 @@ class AwsScannerArgumentParser:
     def _add_audit_s3_command(self, subparsers: Any) -> None:
         desc = "audit S3 bucket compliance"
         audit_parser = subparsers.add_parser(AwsScannerCommands.audit_s3, help=desc, description=desc)
+        self._add_auth_args(audit_parser)
+        self._add_accounts_args(audit_parser)
+        self._add_verbosity_arg(audit_parser)
+
+    def _add_audit_iam_command(self, subparsers: Any) -> None:
+        desc = "audit iam compliance"
+        audit_parser = subparsers.add_parser(AwsScannerCommands.audit_iam, help=desc, description=desc)
         self._add_auth_args(audit_parser)
         self._add_accounts_args(audit_parser)
         self._add_verbosity_arg(audit_parser)

--- a/src/aws_task_builder.py
+++ b/src/aws_task_builder.py
@@ -7,6 +7,7 @@ from src.clients.aws_organizations_client import AwsOrganizationsClient
 from src.data.aws_organizations_types import Account
 from src.tasks.aws_athena_cleaner_task import AwsAthenaCleanerTask
 from src.tasks.aws_audit_s3_task import AwsAuditS3Task
+from src.tasks.aws_audit_iam_task import AwsAuditIamTask
 from src.tasks.aws_audit_vpc_flow_logs_task import AwsAuditVPCFlowLogsTask
 from src.tasks.aws_create_athena_table_task import AwsCreateAthenaTableTask
 from src.tasks.aws_list_accounts_task import AwsListAccountsTask
@@ -42,6 +43,7 @@ class AwsTaskBuilder:
             Cmd.list_ssm_parameters: lambda: self._tasks(AwsListSSMParametersTask, args.accounts),
             Cmd.drop: lambda: self._standalone_task(AwsAthenaCleanerTask),
             Cmd.audit_s3: lambda: self._tasks(AwsAuditS3Task, args.accounts),
+            Cmd.audit_iam: lambda: self._tasks(AwsAuditIamTask, args.accounts),
             Cmd.cost_explorer: lambda: self._services_tasks(
                 AwsAuditCostExplorerTask, args.accounts, services=args.services, year=args.year, month=args.month
             ),

--- a/src/aws_task_runner.py
+++ b/src/aws_task_runner.py
@@ -6,6 +6,7 @@ from src.data.aws_task_report import AwsTaskReport
 from src.clients.aws_client_factory import AwsClientFactory
 from src.tasks.aws_athena_task import AwsAthenaTask
 from src.tasks.aws_audit_cost_explorer_task import AwsAuditCostExplorerTask
+from src.tasks.aws_audit_iam_task import AwsAuditIamTask
 from src.tasks.aws_organizations_task import AwsOrganizationsTask
 from src.tasks.aws_ssm_task import AwsSSMTask
 from src.tasks.aws_s3_task import AwsS3Task
@@ -37,4 +38,6 @@ class AwsTaskRunner:
             return task.run(self._client_factory.get_s3_client(task.account))
         elif isinstance(task, AwsVpcTask):
             return task.run(self._client_factory.get_vpc_client(task.account))
+        elif isinstance(task, AwsAuditIamTask):
+            return task.run(self._client_factory.get_iam_client(task.account))
         raise UnsupportedTaskException(task)

--- a/src/clients/aws_iam_client.py
+++ b/src/clients/aws_iam_client.py
@@ -6,7 +6,7 @@ from botocore.client import BaseClient
 from botocore.exceptions import BotoCoreError, ClientError
 
 from src.data.aws_common_types import Tag
-from src.data.aws_iam_types import Policy, Role, to_policy, to_role
+from src.data.aws_iam_types import Policy, Role, to_policy, to_role, User, AccessKey
 from src.data.aws_scanner_exceptions import IamException
 
 
@@ -138,3 +138,36 @@ class AwsIamClient:
     def _enrich_policy(self, policy: Policy) -> Policy:
         policy.document = self._get_policy_document(policy.arn, policy.default_version)
         return policy
+
+    def list_users(self) -> Sequence[User]:
+        try:
+            return [
+                User(user_name=user["UserName"])
+                for page in self._iam.get_paginator("list_users").paginate()
+                for user in page["Users"]
+            ]
+        except (BotoCoreError, ClientError) as e:
+            raise IamException(f"unable to list users: {e}")
+
+    def list_access_keys(self, user: User) -> Sequence[AccessKey]:
+        try:
+            return [
+                AccessKey(user_name=key["UserName"], id=key["AccessKeyId"], created=key["CreateDate"])
+                for page in self._iam.get_paginator("list_access_keys").paginate(UserName=user.user_name)
+                for key in page["AccessKeyMetadata"]
+            ]
+        except (BotoCoreError, ClientError) as e:
+            getLogger().warning(f"unable to list access keys: {e}")
+            return []
+
+    def get_access_key_last_used(self, access_key: AccessKey) -> Any:
+        try:
+            last_used = self._iam.get_access_key_last_used(AccessKeyId=access_key.id)["AccessKeyLastUsed"]
+            if "LastUsedDate" in last_used:
+                return last_used["LastUsedDate"]
+
+        except (BotoCoreError, ClientError) as e:
+            key_id = access_key.id
+            getLogger().warning(f"unable to get access key last used for key: {key_id}: {e}")
+
+        return None

--- a/src/data/aws_iam_types.py
+++ b/src/data/aws_iam_types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, Dict, Optional, Sequence
 
 from src.data.aws_common_types import Tag
@@ -48,3 +49,16 @@ class Policy:
 
 def to_policy(policy: Dict[Any, Any]) -> Policy:
     return Policy(name=policy["PolicyName"], arn=policy["Arn"], default_version=policy["DefaultVersionId"])
+
+
+@dataclass
+class User:
+    user_name: str
+
+
+@dataclass
+class AccessKey:
+    id: str
+    user_name: str
+    created: datetime
+    last_used: Optional[datetime] = None

--- a/src/json_serializer.py
+++ b/src/json_serializer.py
@@ -1,10 +1,23 @@
+import datetime
 from json import dumps
 from typing import Any
 
 
 def to_json(obj: Any) -> str:
-    return dumps(obj, default=lambda o: {k: v for k, v in vars(o).items() if _is_public(k) and v and not callable(v)})
+    return dumps(
+        obj,
+        default=lambda o: {
+            k: _datetime_to_string(v) for k, v in vars(o).items() if _is_public(k) and v and not callable(v)
+        },
+    )
 
 
 def _is_public(prop: str) -> bool:
     return not prop.startswith("_")
+
+
+def _datetime_to_string(o: Any) -> Any:
+    if isinstance(o, datetime.datetime):
+        return o.isoformat()
+    else:
+        return o

--- a/src/tasks/aws_audit_iam_task.py
+++ b/src/tasks/aws_audit_iam_task.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict
 
+from src.clients.aws_iam_client import AwsIamClient
 from src.data.aws_organizations_types import Account
 from src.tasks.aws_task import AwsTask
 
@@ -8,5 +9,11 @@ class AwsAuditIamTask(AwsTask):
     def __init__(self, account: Account) -> None:
         super().__init__("audit iam compliance", account)
 
-    def _run_task(self) -> Dict[Any, Any]:
-        raise NotImplementedError("this is an abstract class")
+    def _run_task(self, client: AwsIamClient) -> Dict[Any, Any]:
+        keys = []
+        for user in client.list_users():
+            access_keys = client.list_access_keys(user)
+            for key in access_keys:
+                key.last_used = client.get_access_key_last_used(key)
+                keys.append(key)
+        return {"iam_access_keys": keys}

--- a/src/tasks/aws_audit_iam_task.py
+++ b/src/tasks/aws_audit_iam_task.py
@@ -1,0 +1,12 @@
+from typing import Any, Dict
+
+from src.data.aws_organizations_types import Account
+from src.tasks.aws_task import AwsTask
+
+
+class AwsAuditIamTask(AwsTask):
+    def __init__(self, account: Account) -> None:
+        super().__init__("audit iam compliance", account)
+
+    def _run_task(self) -> Dict[Any, Any]:
+        raise NotImplementedError("this is an abstract class")

--- a/tests/clients/test_aws_iam_client_for_audit_access_keys.py
+++ b/tests/clients/test_aws_iam_client_for_audit_access_keys.py
@@ -1,0 +1,125 @@
+import logging
+import re
+from datetime import datetime
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from src.clients.aws_iam_client import AwsIamClient
+from src.data.aws_iam_types import User, AccessKey
+from src.data.aws_scanner_exceptions import IamException
+from tests.test_types_generator import client_error
+
+
+def test_list_users() -> None:
+    mock_boto_iam = Mock(
+        get_paginator=Mock(
+            return_value=Mock(
+                paginate=Mock(
+                    return_value=[
+                        {"Users": [{"UserName": "User1"}, {"UserName": "User2"}]},
+                        {
+                            "Users": [{"UserName": "User3"}],
+                        },
+                    ]
+                )
+            )
+        )
+    )
+    expected_users = [User(user_name=username) for username in ["User1", "User2", "User3"]]
+
+    assert expected_users == AwsIamClient(mock_boto_iam).list_users()
+
+    mock_boto_iam.get_paginator.assert_called_with("list_users")
+
+
+def test_list_users_exception() -> None:
+    mock_boto_iam = Mock(get_paginator=Mock(side_effect=client_error("ListKeys", "pop", "weasel")))
+
+    with pytest.raises(IamException) as e:
+        AwsIamClient(mock_boto_iam).list_users()
+
+    assert re.search("unable to list users.*pop.*", str(e)) is not None
+
+
+def test_list_access_keys() -> None:
+    user_name = "User1"
+    mock_boto_iam = Mock(
+        get_paginator=Mock(
+            return_value=Mock(
+                paginate=Mock(
+                    return_value=[
+                        {
+                            "AccessKeyMetadata": [
+                                {
+                                    "UserName": user_name,
+                                    "AccessKeyId": "ac1",
+                                    "CreateDate": datetime(2021, 11, 2, 15, 18, 12),
+                                },
+                                {
+                                    "UserName": user_name,
+                                    "AccessKeyId": "ac2",
+                                    "CreateDate": datetime(2021, 10, 12, 5, 34, 3),
+                                },
+                            ]
+                        }
+                    ]
+                )
+            )
+        )
+    )
+    expected_keys = [
+        AccessKey(user_name=user_name, id="ac1", created=datetime(2021, 11, 2, 15, 18, 12)),
+        AccessKey(user_name=user_name, id="ac2", created=datetime(2021, 10, 12, 5, 34, 3)),
+    ]
+
+    assert expected_keys == AwsIamClient(mock_boto_iam).list_access_keys(User(user_name=user_name))
+
+    mock_boto_iam.get_paginator.assert_called_with("list_access_keys")
+    mock_boto_iam.get_paginator.return_value.paginate.assert_called_with(UserName=user_name)
+
+
+def test_list_access_keys_exception_logs_returns_empty_list(caplog: Any) -> None:
+    mock_boto_iam = Mock(get_paginator=Mock(side_effect=client_error("ListAccessKeys", "boom", "what")))
+
+    with caplog.at_level(logging.INFO):
+        assert [] == AwsIamClient(mock_boto_iam).list_access_keys(User(user_name="Brian"))
+
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelname == "WARNING"
+    assert "unable to list access keys" in caplog.text
+    assert "boom" in caplog.text
+
+
+def test_get_access_key_last_used() -> None:
+    last_used = datetime.now()
+    mock_boto_iam = Mock(get_access_key_last_used=Mock(return_value={"AccessKeyLastUsed": {"LastUsedDate": last_used}}))
+    key_id = "keyId"
+    key = AccessKey(user_name="user", id=key_id, created=datetime.now())
+
+    assert last_used == AwsIamClient(mock_boto_iam).get_access_key_last_used(key)
+
+    mock_boto_iam.get_access_key_last_used.assert_called_with(AccessKeyId=key_id)
+
+
+def test_get_access_key_last_used_none() -> None:
+    mock_boto_iam = Mock(get_access_key_last_used=Mock(return_value={"AccessKeyLastUsed": {}}))
+    key = AccessKey(user_name="user", id="keyId", created=datetime.now())
+
+    assert AwsIamClient(mock_boto_iam).get_access_key_last_used(key) is None
+
+
+def test_get_access_key_last_used_exception_returns_none(caplog: Any) -> None:
+    mock_boto_iam = Mock(
+        get_access_key_last_used=Mock(side_effect=client_error("GetAccessKeyLastUsed", "bad stuff", "error"))
+    )
+    key = AccessKey(user_name="user", id="keyId", created=datetime.now())
+
+    with caplog.at_level(logging.INFO):
+        assert AwsIamClient(mock_boto_iam).get_access_key_last_used(key) is None
+
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelname == "WARNING"
+    assert "unable to get access key last used for key: keyId" in caplog.text
+    assert "bad stuff" in caplog.text

--- a/tests/tasks/test_aws_audit_iam_task.py
+++ b/tests/tasks/test_aws_audit_iam_task.py
@@ -1,0 +1,34 @@
+import dataclasses
+import datetime
+from unittest.mock import Mock, call
+from tests.test_types_generator import account
+
+from src.tasks.aws_audit_iam_task import AwsAuditIamTask
+from src.data.aws_iam_types import AccessKey, User
+
+
+def test_run_task() -> None:
+    user1 = User(user_name="user1")
+    user2 = User(user_name="user2")
+    users = [user1, user2]
+    user1_key1 = AccessKey(id="keyid1", user_name=user1.user_name, created=datetime.datetime(2021, 11, 1, 17, 10, 0))
+    user2_key1 = AccessKey(id="u2key1", user_name=user2.user_name, created=datetime.datetime(2020, 10, 15, 1, 23, 27))
+    user2_key2 = AccessKey(id="u2key2", user_name=user2.user_name, created=datetime.datetime(2021, 4, 29, 9, 55, 43))
+    last_used = [datetime.datetime(2021, 11, 2, 8, 45, 12), None, datetime.datetime(2021, 5, 5, 14, 34, 23)]
+    iam_client = Mock(
+        list_users=Mock(return_value=users),
+        list_access_keys=Mock(side_effect=[[user1_key1], [user2_key1, user2_key2]]),
+        get_access_key_last_used=Mock(side_effect=last_used),
+    )
+    expected_report = {
+        "iam_access_keys": [
+            dataclasses.replace(user1_key1, last_used=last_used[0]),
+            dataclasses.replace(user2_key1),
+            dataclasses.replace(user2_key2, last_used=last_used[2]),
+        ]
+    }
+
+    assert expected_report == AwsAuditIamTask(account())._run_task(iam_client)
+
+    assert iam_client.list_access_keys.call_args_list == [call(user1), call(user2)]
+    assert iam_client.get_access_key_last_used.call_args_list == [call(user1_key1), call(user2_key1), call(user2_key2)]

--- a/tests/tasks/test_aws_iam_task.py
+++ b/tests/tasks/test_aws_iam_task.py
@@ -1,0 +1,6 @@
+from unittest import TestCase
+from unittest.mock import Mock
+
+from tests.test_types_generator import iam_task
+
+

--- a/tests/tasks/test_aws_iam_task.py
+++ b/tests/tasks/test_aws_iam_task.py
@@ -1,6 +1,0 @@
-from unittest import TestCase
-from unittest.mock import Mock
-
-from tests.test_types_generator import iam_task
-
-

--- a/tests/test_aws_parallel_task_runner.py
+++ b/tests/test_aws_parallel_task_runner.py
@@ -31,7 +31,8 @@ class TestAwsParallelTaskRunner(TestCase):
             task_report(description="other task", results={"outcome_2": "success_2"}, partition=None), reports
         )
 
-        self.assertEqual(
-            ["ERROR:AwsParallelTaskRunner:task 'boom' for 'wrong account (5678)' failed with: 'oops'"],
-            error_log.output,
+        expected_error_msg = (
+            "ERROR:AwsParallelTaskRunner:task 'boom' for 'wrong account (5678)' failed with: "
+            "'AwsScannerException: oops'"
         )
+        self.assertEqual([expected_error_msg], error_log.output)

--- a/tests/test_aws_task_builder.py
+++ b/tests/test_aws_task_builder.py
@@ -7,6 +7,7 @@ from src.aws_scanner_argument_parser import AwsScannerCommands as Cmd
 from src.aws_task_builder import AwsTaskBuilder
 from src.tasks.aws_athena_cleaner_task import AwsAthenaCleanerTask
 from src.tasks.aws_audit_s3_task import AwsAuditS3Task
+from src.tasks.aws_audit_iam_task import AwsAuditIamTask
 
 from src.tasks.aws_audit_vpc_flow_logs_task import AwsAuditVPCFlowLogsTask
 from src.tasks.aws_create_athena_table_task import AwsCreateAthenaTableTask
@@ -93,6 +94,12 @@ class TestAwsTaskBuilder(TestCase):
         self.assert_tasks_equal(
             [AwsAuditVPCFlowLogsTask(acct1, False), AwsAuditVPCFlowLogsTask(acct2, False)],
             task_builder().build_tasks(args(task=Cmd.audit_vpc_flow_logs, enforce=False)),
+        )
+
+    def test_audit_iam_tasks(self) -> None:
+        self.assert_tasks_equal(
+            [AwsAuditIamTask(acct1), AwsAuditIamTask(acct2)],
+            task_builder().build_tasks(args(task=Cmd.audit_iam)),
         )
 
     def assert_tasks_equal(self, expected: Sequence[AwsTask], actual: Sequence[AwsTask]) -> None:

--- a/tests/test_aws_task_runner.py
+++ b/tests/test_aws_task_runner.py
@@ -7,7 +7,7 @@ from src.tasks.aws_athena_task import AwsAthenaTask
 from src.tasks.aws_audit_cost_explorer_task import AwsAuditCostExplorerTask
 from src.tasks.aws_organizations_task import AwsOrganizationsTask
 
-from tests.test_types_generator import account, athena_task, s3_task, ssm_task, task_report, vpc_task
+from tests.test_types_generator import account, athena_task, audit_iam_task, s3_task, ssm_task, task_report, vpc_task
 
 
 class TestAwsTaskRunner(TestCase):
@@ -70,6 +70,13 @@ class TestAwsTaskRunner(TestCase):
         client = Mock()
         client_factory = Mock(get_vpc_client=Mock(side_effect=lambda acc: client if acc == account() else None))
         task = vpc_task()
+        task.run = Mock(side_effect=lambda c: task_report() if c == client else None)  # type: ignore
+        self.assertEqual(task_report(), AwsTaskRunner(client_factory)._run_task(task))
+
+    def test_run_audit_iam_task(self) -> None:
+        client = Mock()
+        client_factory = Mock(get_iam_client=Mock(side_effect=lambda acc: client if acc == account() else None))
+        task = audit_iam_task()
         task.run = Mock(side_effect=lambda c: task_report() if c == client else None)  # type: ignore
         self.assertEqual(task_report(), AwsTaskRunner(client_factory)._run_task(task))
 

--- a/tests/test_json_serializer.py
+++ b/tests/test_json_serializer.py
@@ -1,3 +1,4 @@
+import datetime
 from unittest import TestCase
 
 from dataclasses import dataclass
@@ -16,3 +17,13 @@ class TestJsonSerializer(TestCase):
         greetings: str = "Bonjour!"
         empty: Optional[str] = None
         func: Callable[[], str] = lambda: "hello"
+
+    def test_serialize_datetime(self) -> None:
+        self.assertEqual(
+            '{"name": "Andy", "born": "2021-11-01T15:30:10"}', to_json(TestJsonSerializer.TestDatetimeObject())
+        )
+
+    @dataclass
+    class TestDatetimeObject:
+        name: str = "Andy"
+        born: datetime.datetime = datetime.datetime(2021, 11, 1, 15, 30, 10)

--- a/tests/test_types_generator.py
+++ b/tests/test_types_generator.py
@@ -52,6 +52,7 @@ from src.tasks.aws_ssm_task import AwsSSMTask
 from src.tasks.aws_s3_task import AwsS3Task
 from src.tasks.aws_task import AwsTask
 from src.tasks.aws_vpc_task import AwsVpcTask
+from src.tasks.aws_audit_iam_task import AwsAuditIamTask
 
 
 def partition(year: int = 2020, month: int = 11, region: str = "eu") -> AwsAthenaDataPartition:
@@ -82,6 +83,10 @@ def vpc_task(account: Account = account(), description: str = "vpc_task", enforc
 
 def s3_task(account: Account = account(), description: str = "s3_task") -> AwsS3Task:
     return AwsS3Task(description=description, account=account)
+
+
+def iam_task(account: Account = account(), description: str = "iam_task") -> AwsAuditIamTask:
+    return AwsAuditIamTask(description=description, account=account)
 
 
 def ssm_task(account: Account = account(), description: str = "ssm_task") -> AwsSSMTask:

--- a/tests/test_types_generator.py
+++ b/tests/test_types_generator.py
@@ -45,6 +45,7 @@ from src.data.aws_s3_types import (
 from src.data.aws_ssm_types import Parameter
 from src.data.aws_task_report import AwsTaskReport
 from src.tasks.aws_athena_task import AwsAthenaTask
+from src.tasks.aws_audit_iam_task import AwsAuditIamTask
 from src.tasks.aws_audit_vpc_flow_logs_task import AwsAuditVPCFlowLogsTask
 from src.tasks.aws_cloudtrail_task import AwsCloudTrailTask
 from src.tasks.aws_organizations_task import AwsOrganizationsTask
@@ -96,6 +97,10 @@ def cloudtrail_task(
     account: Account = account(), description: str = "task", partition: AwsAthenaDataPartition = partition()
 ) -> AwsCloudTrailTask:
     return AwsCloudTrailTask(description=description, account=account, partition=partition)
+
+
+def audit_iam_task(account: Account = account()) -> AwsAuditIamTask:
+    return AwsAuditIamTask(account=account)
 
 
 def task_report(

--- a/tests/test_types_generator.py
+++ b/tests/test_types_generator.py
@@ -52,7 +52,6 @@ from src.tasks.aws_ssm_task import AwsSSMTask
 from src.tasks.aws_s3_task import AwsS3Task
 from src.tasks.aws_task import AwsTask
 from src.tasks.aws_vpc_task import AwsVpcTask
-from src.tasks.aws_audit_iam_task import AwsAuditIamTask
 
 
 def partition(year: int = 2020, month: int = 11, region: str = "eu") -> AwsAthenaDataPartition:
@@ -83,10 +82,6 @@ def vpc_task(account: Account = account(), description: str = "vpc_task", enforc
 
 def s3_task(account: Account = account(), description: str = "s3_task") -> AwsS3Task:
     return AwsS3Task(description=description, account=account)
-
-
-def iam_task(account: Account = account(), description: str = "iam_task") -> AwsAuditIamTask:
-    return AwsAuditIamTask(description=description, account=account)
 
 
 def ssm_task(account: Account = account(), description: str = "ssm_task") -> AwsSSMTask:


### PR DESCRIPTION
- PSEC-1105 dont hide what make/ docker is doing
- PSEC-1105 wire up empty task for iam audit
- PSEC-1105 create iam access keys report
- PSEC-1105 enable datetime serialisation to JSON
- [PSEC-1105] Do not automatically pipe scanner outcome to jq
- [PSEC-1105] log exception type when on task failure
- [PSEC-1105] Inject IAM client in AwsAuditIamTask types
