### PR TITLE
PSEC-1105 set default log level to WARNING

### DIFF
--- a/src/aws_scanner_argument_parser.py
+++ b/src/aws_scanner_argument_parser.py
@@ -90,7 +90,7 @@ class AwsScannerArgumentParser:
             "-v",
             "--verbosity",
             choices=["error", "warning", "info", "debug"],
-            default="error",
+            default="warning",
             help="log level configuration",
         )
 

--- a/tests/test_aws_scanner_argument_parser.py
+++ b/tests/test_aws_scanner_argument_parser.py
@@ -195,6 +195,22 @@ def test_parse_cli_args_for_enfore_false() -> None:
         assert long_args.enforce is False
 
 
+def test_default_log_level_is_warning() -> None:
+    with patch("sys.argv", ". audit_vpc_flow_logs --token 223344".split()):
+        args = AwsScannerArgumentParser().parse_cli_args()
+
+        assert args.log_level == "WARNING"
+
+
+def test_invalid_log_level_logs_and_exits(caplog: Any) -> None:
+    with patch("sys.argv", ". audit_vpc_flow_logs --token 223344 -v banana".split()):
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(SystemExit):
+                AwsScannerArgumentParser().parse_cli_args()
+                assert "banana" in caplog.text
+                assert "verbosity" in caplog.text
+
+
 def test_cli_task_is_mandatory(caplog: Any) -> None:
     with patch("sys.argv", ".".split()):
         with caplog.at_level(logging.ERROR):


### PR DESCRIPTION
both s3 and iam audit tasks log warnings and continue to scan when
there is a boto exception
