### PR TITLE
[PSEC-1108] Improve IAM policy document comparison

### DIFF
--- a/aws_scanner_test_config.ini
+++ b/aws_scanner_test_config.ini
@@ -35,7 +35,7 @@ vpc_log_group_destination = arn:aws:logs:::destination:central
 vpc_log_group_delivery_role = vpc_flow_log_role
 vpc_log_group_delivery_role_assume_policy = {"Statement": [{"Action": "sts:AssumeRole"}]}
 vpc_log_group_delivery_role_policy = delivery_role_policy
-vpc_log_group_delivery_role_policy_document = {"Statement": [{"Effect": "Allow", "Action": ["logs:PutLogEvents"]}]}
+vpc_log_group_delivery_role_policy_document = {"Statement": [{"Effect": "Allow", "Action": ["logs:*"], "Resource": "*"}]}
 vpc_log_group_retention_policy_days = 14
 role = logs_role
 

--- a/src/clients/composite/aws_vpc_client.py
+++ b/src/clients/composite/aws_vpc_client.py
@@ -58,7 +58,8 @@ class AwsVpcClient:
         return bool(
             role
             and role.assume_policy == self.config.logs_vpc_log_group_delivery_role_assume_policy()
-            and [p.document for p in role.policies] == [self.config.logs_vpc_log_group_delivery_role_policy_document()]
+            and role.policies
+            and all(p.doc_equals(self.config.logs_vpc_log_group_delivery_role_policy_document()) for p in role.policies)
         )
 
     def _is_flow_log_centralised(self, flow_log: FlowLog) -> bool:

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,2 +1,8 @@
+from typing import Any, List
+
 SERVICE_ACCOUNT_USER = "__lambda"
 SERVICE_ACCOUNT_TOKEN = "000000"
+
+
+def is_list(target: Any) -> bool:
+    return issubclass(type(target), List)

--- a/src/data/aws_iam_types.py
+++ b/src/data/aws_iam_types.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Dict, Optional, Sequence, Set
 
+from src.data import is_list
 from src.data.aws_common_types import Tag
+from src.data.aws_scanner_exceptions import UnsupportedPolicyDocumentElement
 
 
 @dataclass
@@ -46,9 +48,40 @@ class Policy:
     default_version: str
     document: Optional[Dict[str, Any]] = None
 
+    def document_equals(self, doc: Dict[str, Any]) -> bool:
+        unrolled = self._unroll_statements(self.document) if self.document else set()
+        return unrolled == self._unroll_statements(doc)
+
+    def _unroll_statements(self, doc: Dict[str, Any]) -> Set[Statement]:
+        unrolled = set()
+        statements = doc["Statement"] if is_list(doc["Statement"]) else [doc["Statement"]]
+        for s in self._validate_statements(statements):
+            actions = s["Action"] if is_list(s["Action"]) else [s["Action"]]
+            resources = s["Resource"] if is_list(s["Resource"]) else [s["Resource"]]
+            for a in actions:
+                for r in resources:
+                    unrolled.add(Statement(action=a, resource=r, effect=s["Effect"], condition=str(s.get("Condition"))))
+        return unrolled
+
+    @staticmethod
+    def _validate_statements(statements: Sequence[Dict[str, Any]]) -> Sequence[Dict[str, Any]]:
+        unsupported_elements = ["NotAction", "NotResource", "Principal", "NotPrincipal"]
+        invalid_statements = [s for s in statements if any(element in s for element in unsupported_elements)]
+        if invalid_statements:
+            raise UnsupportedPolicyDocumentElement(f"one of {unsupported_elements} found in {invalid_statements}")
+        return statements
+
 
 def to_policy(policy: Dict[Any, Any]) -> Policy:
     return Policy(name=policy["PolicyName"], arn=policy["Arn"], default_version=policy["DefaultVersionId"])
+
+
+@dataclass(frozen=True)
+class Statement:
+    action: str
+    condition: Optional[str]
+    effect: str
+    resource: str
 
 
 @dataclass

--- a/src/data/aws_iam_types.py
+++ b/src/data/aws_iam_types.py
@@ -48,7 +48,7 @@ class Policy:
     default_version: str
     document: Optional[Dict[str, Any]] = None
 
-    def document_equals(self, doc: Dict[str, Any]) -> bool:
+    def doc_equals(self, doc: Dict[str, Any]) -> bool:
         unrolled = self._unroll_statements(self.document) if self.document else set()
         return unrolled == self._unroll_statements(doc)
 

--- a/src/data/aws_scanner_exceptions.py
+++ b/src/data/aws_scanner_exceptions.py
@@ -85,5 +85,9 @@ class UnknownQueryStateException(AwsScannerException):
     pass
 
 
+class UnsupportedPolicyDocumentElement(AwsScannerException):
+    pass
+
+
 class UnsupportedTaskException(AwsScannerException):
     pass

--- a/tests/clients/test_aws_vpc_client.py
+++ b/tests/clients/test_aws_vpc_client.py
@@ -71,7 +71,7 @@ class TestAwsLogDeliveryRoleCompliance(TestCase):
     def test_flow_log_role_compliant(self) -> None:
         delivery_role = role(
             assume_policy={"Statement": [{"Action": "sts:AssumeRole"}]},
-            policies=[policy(document={"Statement": [{"Effect": "Allow", "Action": ["logs:PutLogEvents"]}]})],
+            policies=[policy(document={"Statement": [{"Effect": "Allow", "Action": ["logs:*"], "Resource": "*"}]})],
         )
         client = AwsVpcClientBuilder().build()
         self.assertTrue(client._is_flow_log_role_compliant(delivery_role))
@@ -83,7 +83,7 @@ class TestAwsLogDeliveryRoleCompliance(TestCase):
         )
         invalid_policy_document = role(
             assume_policy={"Statement": [{"Action": "sts:AssumeRole"}]},
-            policies=[policy(document={"Statement": [{"Effect": "Allow", "Action": ["logs:bla"]}]})],
+            policies=[policy(document={"Statement": [{"Effect": "Allow", "Action": ["logs:bla"], "Resource": "*"}]})],
         )
         missing_policy_document = role(assume_policy={"Statement": [{"Action": "sts:AssumeRole"}]}, policies=[])
         client = AwsVpcClientBuilder().build()

--- a/tests/data/test_aws_iam_types.py
+++ b/tests/data/test_aws_iam_types.py
@@ -5,7 +5,7 @@ from src.data.aws_scanner_exceptions import UnsupportedPolicyDocumentElement
 from tests.test_types_generator import policy
 
 
-def test_policy_document_equals_multi_statements() -> None:
+def test_policy_doc_equals() -> None:
     single_statement = {
         "Statement": {"Effect": "Allow", "Action": ["a:2", "a:1", "b:2", "b:3", "b:1"], "Resource": ["1", "2"]}
     }
@@ -17,10 +17,10 @@ def test_policy_document_equals_multi_statements() -> None:
             {"Effect": "Allow", "Action": ["a:1", "b:3"], "Resource": ["2", "1"]},
         ],
     }
-    assert policy(document=single_statement).document_equals(multi_statements)
+    assert policy(document=single_statement).doc_equals(multi_statements)
 
 
-def test_policy_document_equals_with_condition() -> None:
+def test_policy_doc_equals_with_condition() -> None:
     single_statement = {
         "Statement": {"Effect": "Deny", "Action": "e:7", "Resource": ["abc", "def"], "Condition": {"a": {"b": "c"}}},
     }
@@ -30,58 +30,58 @@ def test_policy_document_equals_with_condition() -> None:
             {"Effect": "Deny", "Action": "e:7", "Resource": "abc", "Condition": {"a": {"b": "c"}}},
         ],
     }
-    assert policy(document=single_statement).document_equals(multi_statements)
+    assert policy(document=single_statement).doc_equals(multi_statements)
 
 
-def test_policy_document_not_equals_when_effect_mismatch() -> None:
+def test_policy_doc_not_equals_when_effect_mismatch() -> None:
     doc_a = {"Statement": {"Effect": "Allow", "Action": "a:1", "Resource": "1"}}
     doc_b = {"Statement": {"Effect": "Deny", "Action": "a:1", "Resource": "1"}}
-    assert not policy(document=doc_a).document_equals(doc_b)
+    assert not policy(document=doc_a).doc_equals(doc_b)
 
 
-def test_policy_document_not_equals_when_action_mismatch() -> None:
+def test_policy_doc_not_equals_when_action_mismatch() -> None:
     doc_a = {"Statement": {"Effect": "Allow", "Action": "a:1", "Resource": "1"}}
     doc_b = {"Statement": {"Effect": "Allow", "Action": "b:1", "Resource": "1"}}
-    assert not policy(document=doc_a).document_equals(doc_b)
+    assert not policy(document=doc_a).doc_equals(doc_b)
 
 
-def test_policy_document_not_equals_when_resource_mismatch() -> None:
+def test_policy_doc_not_equals_when_resource_mismatch() -> None:
     doc_a = {"Statement": {"Effect": "Allow", "Action": "a:1", "Resource": "1"}}
     doc_b = {"Statement": {"Effect": "Allow", "Action": "a:1", "Resource": "2"}}
-    assert not policy(document=doc_a).document_equals(doc_b)
+    assert not policy(document=doc_a).doc_equals(doc_b)
 
 
-def test_policy_document_not_equals_when_condition_mismatch() -> None:
+def test_policy_doc_not_equals_when_condition_mismatch() -> None:
     doc_a = {"Statement": {"Effect": "Allow", "Action": "a:1", "Resource": "1", "Condition": {"banana": 9}}}
     doc_b = {"Statement": {"Effect": "Allow", "Action": "a:1", "Resource": "1"}}
-    assert not policy(document=doc_a).document_equals(doc_b)
+    assert not policy(document=doc_a).doc_equals(doc_b)
 
 
-def test_policy_document_equals_ignores_sid() -> None:
+def test_policy_doc_equals_ignores_sid() -> None:
     doc_a = {"Statement": {"Effect": "Allow", "Action": "a:1", "Resource": "1", "Sid": "blue"}}
     doc_b = {"Statement": {"Effect": "Allow", "Action": "a:1", "Resource": "1", "Sid": "gray"}}
-    assert policy(document=doc_a).document_equals(doc_b)
+    assert policy(document=doc_a).doc_equals(doc_b)
 
 
-def test_policy_document_equals_not_action_unsupported() -> None:
+def test_policy_doc_equals_not_action_unsupported() -> None:
     doc = {"Statement": {"Effect": "Allow", "NotAction": "a:1", "Resource": "1"}}
     with raises(UnsupportedPolicyDocumentElement, match="NotAction"):
-        policy().document_equals(doc)
+        policy().doc_equals(doc)
 
 
-def test_policy_document_equals_not_resource_unsupported() -> None:
+def test_policy_doc_equals_not_resource_unsupported() -> None:
     doc = {"Statement": {"Effect": "Allow", "Action": "a:1", "NotResource": "1"}}
     with raises(UnsupportedPolicyDocumentElement, match="NotResource"):
-        policy().document_equals(doc)
+        policy().doc_equals(doc)
 
 
-def test_policy_document_equals_principal_unsupported() -> None:
+def test_policy_doc_equals_principal_unsupported() -> None:
     doc = {"Statement": {"Effect": "Allow", "Action": "a:1", "Principal": "1"}}
     with raises(UnsupportedPolicyDocumentElement, match="Principal"):
-        policy().document_equals(doc)
+        policy().doc_equals(doc)
 
 
-def test_policy_document_equals_not_principal_unsupported() -> None:
+def test_policy_doc_equals_not_principal_unsupported() -> None:
     doc = {"Statement": {"Effect": "Allow", "Action": "a:1", "NotPrincipal": "1"}}
     with raises(UnsupportedPolicyDocumentElement, match="NotPrincipal"):
-        policy().document_equals(doc)
+        policy().doc_equals(doc)

--- a/tests/data/test_aws_iam_types.py
+++ b/tests/data/test_aws_iam_types.py
@@ -1,0 +1,87 @@
+from pytest import raises
+
+from src.data.aws_scanner_exceptions import UnsupportedPolicyDocumentElement
+
+from tests.test_types_generator import policy
+
+
+def test_policy_document_equals_multi_statements() -> None:
+    single_statement = {
+        "Statement": {"Effect": "Allow", "Action": ["a:2", "a:1", "b:2", "b:3", "b:1"], "Resource": ["1", "2"]}
+    }
+    multi_statements = {
+        "Statement": [
+            {"Effect": "Allow", "Action": ["b:1", "b:2", "a:2"], "Resource": "1"},
+            {"Effect": "Allow", "Action": ["b:1", "b:2"], "Resource": "2"},
+            {"Effect": "Allow", "Action": "a:2", "Resource": "2"},
+            {"Effect": "Allow", "Action": ["a:1", "b:3"], "Resource": ["2", "1"]},
+        ],
+    }
+    assert policy(document=single_statement).document_equals(multi_statements)
+
+
+def test_policy_document_equals_with_condition() -> None:
+    single_statement = {
+        "Statement": {"Effect": "Deny", "Action": "e:7", "Resource": ["abc", "def"], "Condition": {"a": {"b": "c"}}},
+    }
+    multi_statements = {
+        "Statement": [
+            {"Effect": "Deny", "Action": "e:7", "Resource": "def", "Condition": {"a": {"b": "c"}}},
+            {"Effect": "Deny", "Action": "e:7", "Resource": "abc", "Condition": {"a": {"b": "c"}}},
+        ],
+    }
+    assert policy(document=single_statement).document_equals(multi_statements)
+
+
+def test_policy_document_not_equals_when_effect_mismatch() -> None:
+    doc_a = {"Statement": {"Effect": "Allow", "Action": "a:1", "Resource": "1"}}
+    doc_b = {"Statement": {"Effect": "Deny", "Action": "a:1", "Resource": "1"}}
+    assert not policy(document=doc_a).document_equals(doc_b)
+
+
+def test_policy_document_not_equals_when_action_mismatch() -> None:
+    doc_a = {"Statement": {"Effect": "Allow", "Action": "a:1", "Resource": "1"}}
+    doc_b = {"Statement": {"Effect": "Allow", "Action": "b:1", "Resource": "1"}}
+    assert not policy(document=doc_a).document_equals(doc_b)
+
+
+def test_policy_document_not_equals_when_resource_mismatch() -> None:
+    doc_a = {"Statement": {"Effect": "Allow", "Action": "a:1", "Resource": "1"}}
+    doc_b = {"Statement": {"Effect": "Allow", "Action": "a:1", "Resource": "2"}}
+    assert not policy(document=doc_a).document_equals(doc_b)
+
+
+def test_policy_document_not_equals_when_condition_mismatch() -> None:
+    doc_a = {"Statement": {"Effect": "Allow", "Action": "a:1", "Resource": "1", "Condition": {"banana": 9}}}
+    doc_b = {"Statement": {"Effect": "Allow", "Action": "a:1", "Resource": "1"}}
+    assert not policy(document=doc_a).document_equals(doc_b)
+
+
+def test_policy_document_equals_ignores_sid() -> None:
+    doc_a = {"Statement": {"Effect": "Allow", "Action": "a:1", "Resource": "1", "Sid": "blue"}}
+    doc_b = {"Statement": {"Effect": "Allow", "Action": "a:1", "Resource": "1", "Sid": "gray"}}
+    assert policy(document=doc_a).document_equals(doc_b)
+
+
+def test_policy_document_equals_not_action_unsupported() -> None:
+    doc = {"Statement": {"Effect": "Allow", "NotAction": "a:1", "Resource": "1"}}
+    with raises(UnsupportedPolicyDocumentElement, match="NotAction"):
+        policy().document_equals(doc)
+
+
+def test_policy_document_equals_not_resource_unsupported() -> None:
+    doc = {"Statement": {"Effect": "Allow", "Action": "a:1", "NotResource": "1"}}
+    with raises(UnsupportedPolicyDocumentElement, match="NotResource"):
+        policy().document_equals(doc)
+
+
+def test_policy_document_equals_principal_unsupported() -> None:
+    doc = {"Statement": {"Effect": "Allow", "Action": "a:1", "Principal": "1"}}
+    with raises(UnsupportedPolicyDocumentElement, match="Principal"):
+        policy().document_equals(doc)
+
+
+def test_policy_document_equals_not_principal_unsupported() -> None:
+    doc = {"Statement": {"Effect": "Allow", "Action": "a:1", "NotPrincipal": "1"}}
+    with raises(UnsupportedPolicyDocumentElement, match="NotPrincipal"):
+        policy().document_equals(doc)

--- a/tests/test_aws_scanner_config.py
+++ b/tests/test_aws_scanner_config.py
@@ -34,7 +34,7 @@ def test_init_config_from_file() -> None:
     assert "vpc_flow_log_role" == config.logs_vpc_log_group_delivery_role()
     assert {"Statement": [{"Action": "sts:AssumeRole"}]} == config.logs_vpc_log_group_delivery_role_assume_policy()
     assert {
-        "Statement": [{"Action": ["logs:PutLogEvents"], "Effect": "Allow"}]
+        "Statement": [{"Action": ["logs:*"], "Effect": "Allow", "Resource": "*"}]
     } == config.logs_vpc_log_group_delivery_role_policy_document()
     assert 14 == config.logs_vpc_log_group_retention_policy_days()
     assert "logs_role" == config.logs_role()

--- a/tests/test_types_generator.py
+++ b/tests/test_types_generator.py
@@ -273,7 +273,7 @@ def role(
             policy(
                 name="vpc_flow_log_role_policy",
                 arn="arn:vpc_flow_log_role_policy",
-                document={"Statement": [{"Effect": "Allow", "Action": ["logs:PutLogEvents"]}]},
+                document={"Statement": [{"Effect": "Allow", "Action": ["logs:*"], "Resource": "*"}]},
             )
         ],
         tags=tags,


### PR DESCRIPTION
Before these changes, a flow log delivery role that had actions/resources/statements in a different order than the configurable policy that's checked against would fail compliance check. A better policy document comparator is proposed in this PR. The comparator unrolls policy documents into individual statements and can then compare against the desired policy as configured.