### PR TITLE
[PSEC-1455] Add a flow logs subscription filter flag

### DIFF
--- a/src/aws_scanner_argument_parser.py
+++ b/src/aws_scanner_argument_parser.py
@@ -23,6 +23,7 @@ class AwsScannerArguments:
     log_level: str
     enforce: bool
     disable_account_lookup: bool
+    with_subscription_filter: bool
 
     @property
     def partition(self) -> AwsAthenaDataPartition:
@@ -149,6 +150,7 @@ class AwsScannerArgumentParser:
         self._add_auth_args(audit_parser)
         self._add_accounts_args(audit_parser)
         self._add_enforce_arg(audit_parser, "add centralised flow logs to VPCs that don't already have one")
+        audit_parser.add_argument("-w", "--with_subscription_filter", type=bool, help="create subscription filter")
         self._add_verbosity_arg(audit_parser)
 
     def _add_create_table_command(self, subparsers: Any) -> None:
@@ -222,4 +224,5 @@ class AwsScannerArgumentParser:
             log_level=str(args.get("verbosity")).upper(),
             enforce=bool(args.get("enforce")),
             disable_account_lookup=bool(args.get("disable_account_lookup")),
+            with_subscription_filter=bool(args.get("with_subscription_filter")),
         )

--- a/src/aws_scanner_config.py
+++ b/src/aws_scanner_config.py
@@ -71,6 +71,9 @@ class AwsScannerConfig:
     def logs_vpc_log_group_name(self) -> str:
         return self._get_config("logs", "vpc_log_group_name")
 
+    def logs_vpc_log_group_subscription_filter_name(self) -> str:
+        return f"{self.logs_vpc_log_group_name()}_sub_filter"
+
     def logs_vpc_log_group_pattern(self) -> str:
         return self._get_config("logs", "vpc_log_group_pattern")
 

--- a/src/aws_task_builder.py
+++ b/src/aws_task_builder.py
@@ -62,7 +62,10 @@ class AwsTaskBuilder:
                 month=self._args.month,
             ),
             Cmd.audit_vpc_flow_logs: lambda: self._tasks(
-                AwsAuditVPCFlowLogsTask, self._args.accounts, enforce=self._args.enforce
+                AwsAuditVPCFlowLogsTask,
+                self._args.accounts,
+                enforce=self._args.enforce,
+                with_subscription_filter=self._args.with_subscription_filter,
             ),
         }
         return task_mapping[self._args.task]()

--- a/src/clients/aws_logs_client.py
+++ b/src/clients/aws_logs_client.py
@@ -77,6 +77,14 @@ class AwsLogsClient:
         except (BotoCoreError, ClientError) as err:
             raise LogsException(f"unable to put subscription filter '{filter_name}': {err}") from None
 
+    def delete_subscription_filter(self, log_group_name: str, filter_name: str) -> None:
+        try:
+            self._logs.delete_subscription_filter(logGroupName=log_group_name, filterName=filter_name)
+        except (BotoCoreError, ClientError) as err:
+            raise LogsException(
+                f"unable to delete subscription filter '{filter_name}' in log group '{log_group_name}': {err}"
+            ) from None
+
     def put_retention_policy(self, log_group_name: str, retention_days: int) -> None:
         try:
             self._logs.put_retention_policy(logGroupName=log_group_name, retentionInDays=retention_days)

--- a/src/data/aws_compliance_actions.py
+++ b/src/data/aws_compliance_actions.py
@@ -184,12 +184,37 @@ class PutVpcLogGroupSubscriptionFilterAction(ComplianceAction):
 
     def _apply(self) -> None:
         config = Config()
-        log_group_name = config.logs_vpc_log_group_name()
         self.logs.put_subscription_filter(
-            log_group_name=log_group_name,
-            filter_name=f"{log_group_name}_sub_filter",
+            log_group_name=config.logs_vpc_log_group_name(),
+            filter_name=config.logs_vpc_log_group_subscription_filter_name(),
             filter_pattern=config.logs_vpc_log_group_pattern(),
             destination_arn=config.logs_vpc_log_group_destination(),
+        )
+
+
+@dataclass
+class DeleteVpcLogGroupSubscriptionFilterAction(ComplianceAction):
+    logs: AwsLogsClient
+
+    def __init__(self, logs: AwsLogsClient) -> None:
+        super().__init__("Delete central VPC log group subscription filter")
+        self.logs = logs
+
+    def plan(self) -> ComplianceActionReport:
+        config = Config()
+        return ComplianceActionReport(
+            description=self.description,
+            details=dict(
+                log_group_name=config.logs_vpc_log_group_name(),
+                subscription_filter_name=config.logs_vpc_log_group_subscription_filter_name(),
+            ),
+        )
+
+    def _apply(self) -> None:
+        config = Config()
+        self.logs.delete_subscription_filter(
+            log_group_name=config.logs_vpc_log_group_name(),
+            filter_name=config.logs_vpc_log_group_subscription_filter_name(),
         )
 
 

--- a/src/tasks/aws_audit_vpc_flow_logs_task.py
+++ b/src/tasks/aws_audit_vpc_flow_logs_task.py
@@ -8,12 +8,13 @@ from src.tasks.aws_vpc_task import AwsVpcTask
 
 @dataclass
 class AwsAuditVPCFlowLogsTask(AwsVpcTask):
-    def __init__(self, account: Account, enforce: bool) -> None:
+    def __init__(self, account: Account, enforce: bool, with_subscription_filter: bool) -> None:
         super().__init__("audit VPC flow logs compliance", account, enforce)
+        self.with_subscription_filter = with_subscription_filter
 
     def _run_task(self, client: AwsVpcClient) -> Dict[Any, Any]:
         vpcs = client.list_vpcs()
-        actions = client.enforcement_actions(vpcs)
+        actions = client.enforcement_actions(vpcs, self.with_subscription_filter)
         if self.enforce:
             apply = [a.apply() for a in actions]
             return {"vpcs": vpcs, "enforcement_actions": apply}

--- a/tests/clients/test_aws_logs_client.py
+++ b/tests/clients/test_aws_logs_client.py
@@ -97,3 +97,15 @@ def test_put_retention_policy_failure() -> None:
     boto = Mock(put_retention_policy=Mock(side_effect=client_error("PutRetentionPolicy", "Error", "boom")))
     with raises(LogsException, match="14 days retention policy for log group 'broken_log_group'"):
         AwsLogsClient(boto).put_retention_policy("broken_log_group", 14)
+
+
+def test_delete_subscription_filter() -> None:
+    boto = Mock()
+    AwsLogsClient(boto).delete_subscription_filter("a_log_group", "a_filter")
+    boto.delete_subscription_filter.assert_called_once_with(logGroupName="a_log_group", filterName="a_filter")
+
+
+def test_delete_subscription_filter_failure() -> None:
+    boto = Mock(delete_subscription_filter=Mock(side_effect=client_error("DeleteSubscriptionFilter", "No", "no!")))
+    with raises(LogsException, match="some_broken_filter"):
+        AwsLogsClient(boto).delete_subscription_filter("a_log_group", "some_broken_filter")

--- a/tests/data/test_aws_compliance_actions.py
+++ b/tests/data/test_aws_compliance_actions.py
@@ -18,6 +18,7 @@ from tests.test_types_generator import (
     create_flow_log_action,
     create_flow_log_delivery_role_action,
     delete_flow_log_delivery_role_action,
+    delete_vpc_log_group_subscription_filter_action,
     create_vpc_log_group_action,
     put_vpc_log_group_subscription_filter_action,
     put_vpc_log_group_retention_policy_action,
@@ -149,6 +150,22 @@ def test_apply_put_central_vpc_log_group_subscription_filter_action() -> None:
 def test_plan_put_central_vpc_log_group_subscription_filter_action() -> None:
     expected = compliance_action_report(description="Put central VPC log group subscription filter")
     assert expected == put_vpc_log_group_subscription_filter_action().plan()
+
+
+def test_apply_delete_vpc_log_group_subscription_filter_action() -> None:
+    logs = Mock(spec=AwsLogsClient)
+    delete_vpc_log_group_subscription_filter_action(logs=logs)._apply()
+    logs.delete_subscription_filter.assert_called_once_with(
+        log_group_name="/vpc/flow_log", filter_name="/vpc/flow_log_sub_filter"
+    )
+
+
+def test_plan_delete_vpc_log_group_subscription_filter_action() -> None:
+    expected = compliance_action_report(
+        description="Delete central VPC log group subscription filter",
+        details=dict(log_group_name="/vpc/flow_log", subscription_filter_name="/vpc/flow_log_sub_filter"),
+    )
+    assert expected == delete_vpc_log_group_subscription_filter_action().plan()
 
 
 def test_plan_put_vpc_log_group_retention_policy_action() -> None:

--- a/tests/tasks/test_aws_audit_vpc_flow_logs_task.py
+++ b/tests/tasks/test_aws_audit_vpc_flow_logs_task.py
@@ -22,8 +22,12 @@ vpcs = [vpc(id="vpc-1"), vpc(id="vpc-2")]
 actions = [delete_flow_log_action(flow_log_id="fl-4"), create_flow_log_action(vpc_id="vpc-7")]
 
 
-def enforcement_actions(v: Sequence[Vpc]) -> Sequence[ComplianceAction]:
-    return [delete_flow_log_action(flow_log_id="fl-4"), create_flow_log_action(vpc_id="vpc-7")] if v == vpcs else []
+def enforcement_actions(v: Sequence[Vpc], with_sub_filter: bool) -> Sequence[ComplianceAction]:
+    return (
+        [delete_flow_log_action(flow_log_id="fl-4"), create_flow_log_action(vpc_id="vpc-7")]
+        if v == vpcs and with_sub_filter
+        else []
+    )
 
 
 @patch.object(AwsVpcClient, "enforcement_actions", side_effect=enforcement_actions)
@@ -38,7 +42,9 @@ class TestAwsAuditVPCFlowLogsTask(TestCase):
             ),
         ]
         report = self.expected_report(action_reports)
-        self.assertEqual(report, aws_audit_vpc_flow_logs_task(enforce=False).run(vpc_client))
+        self.assertEqual(
+            report, aws_audit_vpc_flow_logs_task(enforce=False, with_subscription_filter=True).run(vpc_client)
+        )
 
     @staticmethod
     def expected_report(action_reports: Sequence[ComplianceActionReport]) -> AwsTaskReport:
@@ -57,4 +63,7 @@ class TestAwsAuditVPCFlowLogsTask(TestCase):
                 details=dict(vpc_id="vpc-7", log_group_name="/vpc/flow_log"),
             ),
         ]
-        self.assertEqual(self.expected_report(reports), aws_audit_vpc_flow_logs_task(enforce=True).run(vpc_client))
+        self.assertEqual(
+            self.expected_report(reports),
+            aws_audit_vpc_flow_logs_task(enforce=True, with_subscription_filter=True).run(vpc_client),
+        )

--- a/tests/test_aws_scanner_argument_parser.py
+++ b/tests/test_aws_scanner_argument_parser.py
@@ -186,13 +186,24 @@ def test_parse_cli_args_for_audit_vpc_flow_logs_task() -> None:
         assert args.accounts == ["5", "9"]
         assert args.enforce is True
         assert args.disable_account_lookup is True
+        assert args.with_subscription_filter is False
 
 
-def test_parse_cli_args_for_enfore_false() -> None:
+def test_parse_cli_args_for_enforce_false() -> None:
     with patch("sys.argv", ". audit_vpc_flow_logs --token 223344 --accounts 5,9 --enforce False".split()):
         long_args = AwsScannerArgumentParser().parse_cli_args()
 
         assert long_args.enforce is False
+
+
+def test_parse_cli_args_with_subscription_filter() -> None:
+    with patch("sys.argv", ". audit_vpc_flow_logs --token 223344 --with_subscription_filter true".split()):
+        long_args = AwsScannerArgumentParser().parse_cli_args()
+        assert long_args.with_subscription_filter is True
+
+    with patch("sys.argv", ". audit_vpc_flow_logs -t 223344 -w 1".split()):
+        long_args = AwsScannerArgumentParser().parse_cli_args()
+        assert long_args.with_subscription_filter is True
 
 
 def test_default_log_level_is_warning() -> None:

--- a/tests/test_aws_task_builder.py
+++ b/tests/test_aws_task_builder.py
@@ -103,8 +103,10 @@ class TestAwsTaskBuilder(TestCase):
 
     def test_audit_vpc_flow_logs_tasks(self) -> None:
         self.assert_tasks_equal(
-            [AwsAuditVPCFlowLogsTask(acct1, False), AwsAuditVPCFlowLogsTask(acct2, False)],
-            task_builder(args(task=Cmd.audit_vpc_flow_logs, enforce=False)).build_tasks(),
+            [AwsAuditVPCFlowLogsTask(acct1, False, True), AwsAuditVPCFlowLogsTask(acct2, False, True)],
+            task_builder(
+                args(task=Cmd.audit_vpc_flow_logs, enforce=False, with_subscription_filter=True)
+            ).build_tasks(),
         )
 
     def test_audit_iam_tasks(self) -> None:

--- a/tests/test_types_generator.py
+++ b/tests/test_types_generator.py
@@ -18,6 +18,7 @@ from src.data.aws_compliance_actions import (
     CreateFlowLogDeliveryRoleAction,
     DeleteFlowLogAction,
     DeleteFlowLogDeliveryRoleAction,
+    DeleteVpcLogGroupSubscriptionFilterAction,
     PutVpcLogGroupRetentionPolicyAction,
     PutVpcLogGroupSubscriptionFilterAction,
     TagFlowLogDeliveryRoleAction,
@@ -220,6 +221,7 @@ def aws_scanner_arguments(
     log_level: str = "ERROR",
     enforce: bool = False,
     disable_account_lookup: bool = False,
+    with_subscription_filter: bool = False,
 ) -> AwsScannerArguments:
     return AwsScannerArguments(
         username=username,
@@ -235,6 +237,7 @@ def aws_scanner_arguments(
         log_level=log_level,
         enforce=enforce,
         disable_account_lookup=disable_account_lookup,
+        with_subscription_filter=with_subscription_filter,
     )
 
 
@@ -336,6 +339,12 @@ def put_vpc_log_group_subscription_filter_action(
     return PutVpcLogGroupSubscriptionFilterAction(logs=logs)
 
 
+def delete_vpc_log_group_subscription_filter_action(
+    logs: AwsLogsClient = Mock(spec=AwsLogsClient),
+) -> DeleteVpcLogGroupSubscriptionFilterAction:
+    return DeleteVpcLogGroupSubscriptionFilterAction(logs=logs)
+
+
 def put_vpc_log_group_retention_policy_action(
     logs: AwsLogsClient = Mock(spec=AwsLogsClient),
 ) -> PutVpcLogGroupRetentionPolicyAction:
@@ -352,8 +361,10 @@ def tag_vpc_log_group_action(
     return TagVpcLogGroupAction(logs=logs)
 
 
-def aws_audit_vpc_flow_logs_task(account: Account = account(), enforce: bool = False) -> AwsAuditVPCFlowLogsTask:
-    return AwsAuditVPCFlowLogsTask(account=account, enforce=enforce)
+def aws_audit_vpc_flow_logs_task(
+    account: Account = account(), enforce: bool = False, with_subscription_filter: bool = False
+) -> AwsAuditVPCFlowLogsTask:
+    return AwsAuditVPCFlowLogsTask(account=account, enforce=enforce, with_subscription_filter=with_subscription_filter)
 
 
 def log_group(


### PR DESCRIPTION
When `with_subscription_filter` is false and a central subscription filter exists, it will be deleted
When `with_subscription_filter` is true and a central subscription filter doesn't exist, it will be created

Any other combinations have no effect.