### PR TITLE
BAU unknown instance tag fix

### DIFF
--- a/src/data/aws_ec2_types.py
+++ b/src/data/aws_ec2_types.py
@@ -89,7 +89,7 @@ class Instance:
 def to_instance(instance: Dict[Any, Any]) -> Instance:
     return Instance(
         id=instance["InstanceId"],
-        component="Unknown" if "Tags" not in instance else _find_tag("Name", instance["Tags"]),
+        component=_find_tag("Name", instance.get("Tags", {})),
         image_id=instance["ImageId"],
         image_creation_date=None,
         launch_time=instance["LaunchTime"],

--- a/tests/clients/test_aws_ec2_client_responses.py
+++ b/tests/clients/test_aws_ec2_client_responses.py
@@ -161,7 +161,6 @@ DESCRIBE_INSTANCES = [
                         "ImageId": "ami-5678",
                         "InstanceId": "i-d4e5f6",
                         "LaunchTime": "2022-02-27T17:32:24.000Z",
-                        "Tags": [{"Key": "Name", "Value": "another-component"}],
                         "MetadataOptions": {"HttpTokens": "optional"},
                     }
                 ]
@@ -181,7 +180,7 @@ EXPECTED_INSTANCES = [
     ),
     instance(
         id="i-d4e5f6",
-        component="another-component",
+        component="Unknown",
         image_id="ami-5678",
         image_creation_date="2022-02-21T14:05:14.000Z",
         launch_time="2022-02-27T17:32:24.000Z",


### PR DESCRIPTION
- added missing instance component check and test
- fixed tests and refactor
- Removed duplication by using '.get' dictionary method
- Updated test for missing instance component
