### PR TITLE
TEL-3005 allow expiry tag for 18 month retention

### DIFF
--- a/src/data/aws_s3_types.py
+++ b/src/data/aws_s3_types.py
@@ -114,7 +114,7 @@ def to_bucket_data_tagging(tag_response: Dict[str, List[Dict[str, str]]]) -> Buc
     expiry = (
         expiry_tag
         if expiry_tag
-        in ["1-week", "1-month", "90-days", "6-months", "1-year", "7-years", "10-years", "forever-config-only"]
+        in ["1-week", "1-month", "90-days", "6-months", "18-months", "1-year", "7-years", "10-years", "forever-config-only"]
         else "unset"
     )
     sensitivity_tag = tags.get("data_sensitivity")


### PR DESCRIPTION
Telemetry keep elasticsearch logs for 18 months as agreed with Saskia & Ben. This was added to the AWS S3 bucket policies doc but needs to be added so that Telemetry are no longer alerted for incorrect tags on our s3 buckets