### PR TITLE
Filter out shared vpcs when listing vpcs in an account

### DIFF
--- a/src/clients/aws_client_factory.py
+++ b/src/clients/aws_client_factory.py
@@ -106,7 +106,7 @@ class AwsClientFactory:
         return self._get_client("ec2", account, role)
 
     def get_ec2_client(self, account: Account, role: Optional[str] = None) -> AwsEC2Client:
-        return AwsEC2Client(self.get_ec2_boto_client(account, role or self._config.ec2_role()))
+        return AwsEC2Client(self.get_ec2_boto_client(account, role or self._config.ec2_role()), account=account)
 
     def get_route53_boto_client(self, account: Account, role: str) -> BaseClient:
         return self._get_client("route53", account, role)

--- a/tests/clients/composite/test_aws_vpc_client.py
+++ b/tests/clients/composite/test_aws_vpc_client.py
@@ -874,7 +874,7 @@ class TestLogGroupCompliance(TestCase):
 class AwsVpcClientBuilder(TestCase):
     def __init__(self) -> None:
         super().__init__()
-        self.ec2 = Mock(spec=AwsEC2Client, wraps=AwsEC2Client(Mock()))
+        self.ec2 = Mock(spec=AwsEC2Client, wraps=AwsEC2Client(Mock(), account=account()))
         self.iam = Mock(spec=AwsIamClient, wraps=AwsIamClient(Mock()))
         self.logs = Mock(
             spec=AwsLogsClient,

--- a/tests/clients/test_aws_ec2_client.py
+++ b/tests/clients/test_aws_ec2_client.py
@@ -22,7 +22,7 @@ def test_list_vpcs() -> None:
             assert [vpc(flow_logs=[flow_log()])] == ec2.list_vpcs()
 
 
-def test_list_pcs_filters_by_current_account_id() -> None:
+def test_describe_vpcs_filters_by_current_account_id() -> None:
     test_account_id = "test_id_123"
     ec2 = AwsEC2Client(Mock(), account=account(test_account_id))
     with patch.object(ec2, "_describe_flow_logs", side_effect=lambda v: [flow_log()] if v.id == vpc().id else None):

--- a/tests/clients/test_aws_ec2_client.py
+++ b/tests/clients/test_aws_ec2_client.py
@@ -22,7 +22,7 @@ def test_list_vpcs() -> None:
             assert [vpc(flow_logs=[flow_log()])] == ec2.list_vpcs()
 
 
-def test_list_vpcs_filters_by_curernt_account_id() -> None:
+def test_list_pcs_filters_by_current_account_id() -> None:
     test_account_id = "test_id_123"
     ec2 = AwsEC2Client(Mock(), account=account(test_account_id))
     with patch.object(ec2, "_describe_flow_logs", side_effect=lambda v: [flow_log()] if v.id == vpc().id else None):


### PR DESCRIPTION
This ignores VPCs that show up as "shared" across accounts. We cannot attach resources to these vpcs cross-account therefore, we filter the list by vpc "owner" to the current account. These shared VPCs will be audited when the task runs in the origin account

This fixes a failed apply