### PR TITLE
PSEC-1889 fix typo on parameter to describe vpcs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,10 @@ RUN apk add --no-cache \
     gcc \
     libc-dev \
     make \
-    && pip install pipenv==${PIP_PIPENV_VERSION} --index-url https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple
+    && pip install pipenv==${PIP_PIPENV_VERSION} --index-url "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple/"
 USER builder
 # Install Python dependencies so they are cached
 ARG workdir
 WORKDIR ${workdir}
 COPY --chown=builder:union Pipfile Pipfile.lock ./
-RUN pipenv install --dev --index-url https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple
+RUN pipenv install --dev --index "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple/"

--- a/src/clients/aws_ec2_client.py
+++ b/src/clients/aws_ec2_client.py
@@ -66,7 +66,7 @@ class AwsEC2Client:
     def _describe_vpcs(self, account_id: str) -> List[Vpc]:
         def __describe_vpcs() -> List[Vpc]:
             filters = [{"Name": "owner-id", "Values": [account_id]}]
-            return list(map(to_vpc, self._ec2.describe_vpcs(filters=filters)["Vpcs"]))
+            return list(map(to_vpc, self._ec2.describe_vpcs(Filters=filters)["Vpcs"]))
 
         return boto_try(__describe_vpcs, list, "unable to describe VPCs")
 

--- a/tests/clients/test_aws_ec2_client.py
+++ b/tests/clients/test_aws_ec2_client.py
@@ -44,7 +44,7 @@ def test_describe_vpcs_filters_by_current_account() -> None:
     assert [Vpc("vpc-12312e654bf654d12"), Vpc("vpc-984a4654b65465e12")] == ec2_client._describe_vpcs(
         account_id=account().identifier
     )
-    mock_describe_vpcs.assert_called_once_with(filters=[{"Name": "owner-id", "Values": ["account_id"]}])
+    mock_describe_vpcs.assert_called_once_with(Filters=[{"Name": "owner-id", "Values": ["account_id"]}])
 
 
 def test_describe_vpcs_failure(caplog: Any) -> None:


### PR DESCRIPTION
## What
* Correct case of param being passed

## Why
* Fix errors generated on `audit_vpc_dns_logs` task
* When running task `audit_vpc_dns_logs` seeing:
`Unknown parameter in input: "filters", must be one of: Filters, VpcIds, DryRun, NextToken, MaxResults`

## Resources
* https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/describe_vpcs.html#EC2.Client.describe_vpcs