### PR TITLE
PSEC-1953-improve-ssm-document-audit-report

### DIFF
--- a/src/tasks/aws_audit_ssm_document_task.py
+++ b/src/tasks/aws_audit_ssm_document_task.py
@@ -4,7 +4,6 @@ from typing import Any, Dict
 
 from src.clients.aws_ssm_client import AwsSSMClient
 from src.data.aws_organizations_types import Account
-from src.data.aws_ssm_types import SSMDocument
 from src.tasks.aws_ssm_task import AwsSSMTask
 
 SESSION_MANAGER_RUN_SHELL_DOCUMENT_NAME = "SSM-SessionManagerRunShell"
@@ -19,11 +18,31 @@ class AwsAuditSSMDocumentTask(AwsSSMTask):
     def _run_task(self, client: AwsSSMClient) -> Dict[str, Any]:
         observed = client.get_document(name=SESSION_MANAGER_RUN_SHELL_DOCUMENT_NAME)
         with open(SESSION_MANAGER_RUN_SHELL_JSON_FILE) as f:
-            data = json.load(f)
-            expected = SSMDocument(
-                schema_version=data["schemaVersion"],
-                description=data["description"],
-                session_type=data["sessionType"],
-                inputs=data["inputs"],
-            )
-        return {"documents": [{"name": SESSION_MANAGER_RUN_SHELL_DOCUMENT_NAME, "compliant": expected == observed}]}
+            expected = json.load(f)
+        return {
+            "documents": [
+                {
+                    "name": SESSION_MANAGER_RUN_SHELL_DOCUMENT_NAME,
+                    "compliancy": {
+                        "s3BucketName": {
+                            "compliant": observed.inputs["s3BucketName"] == expected["inputs"]["s3BucketName"],
+                            "message": "S3 bucket name should be mdtp-ssm-session-manager-audit-logs",
+                        },
+                        "s3EncryptionEnabled": {
+                            "compliant": observed.inputs["s3EncryptionEnabled"]
+                            == expected["inputs"]["s3EncryptionEnabled"],
+                            "message": "S3 encryption should be enabled",
+                        },
+                        "maxSessionDuration": {
+                            "compliant": int(observed.inputs["maxSessionDuration"])
+                            <= int(expected["inputs"]["maxSessionDuration"]),
+                            "message": "maxSessionDuration should be less than or equal to 120 mins",
+                        },
+                        "shellProfile": {
+                            "compliant": observed.inputs["shellProfile"] == expected["inputs"]["shellProfile"],
+                            "message": "shellProfile should match expected config",
+                        },
+                    },
+                }
+            ]
+        }

--- a/tests/tasks/test_aws_audit_ssm_document_task.py
+++ b/tests/tasks/test_aws_audit_ssm_document_task.py
@@ -5,6 +5,26 @@ from src.tasks.aws_audit_ssm_document_task import AwsAuditSSMDocumentTask
 from tests.test_types_generator import account
 from tests.test_types_generator import TEST_REGION
 
+REPORT_FULL_COMPLIANCE = {
+    "documents": [
+        {
+            "name": "SSM-SessionManagerRunShell",
+            "compliancy": {
+                "s3BucketName": {
+                    "compliant": True,
+                    "message": "S3 bucket name should be mdtp-ssm-session-manager-audit-logs",
+                },
+                "s3EncryptionEnabled": {"compliant": True, "message": "S3 encryption should be enabled"},
+                "maxSessionDuration": {
+                    "compliant": True,
+                    "message": "maxSessionDuration should be less than or equal to 120 mins",
+                },
+                "shellProfile": {"compliant": True, "message": "shellProfile should match expected config"},
+            },
+        }
+    ]
+}
+
 
 def test_aws_audit_ssm_document_compliance_true() -> None:
     document = SSMDocument(
@@ -24,13 +44,11 @@ def test_aws_audit_ssm_document_compliance_true() -> None:
 
     ssm_client = Mock(get_document=Mock(return_value=document))
     task_report = AwsAuditSSMDocumentTask(account=account(), region=TEST_REGION)._run_task(ssm_client)
-    print(task_report)
-    expected = {"documents": [{"name": "SSM-SessionManagerRunShell", "compliant": True}]}
 
-    assert expected == task_report
+    assert REPORT_FULL_COMPLIANCE == task_report
 
 
-def test_aws_audit_ssm_document_compliance_false() -> None:
+def test_aws_audit_ssm_document_compliance_on_low_max_session_duration() -> None:
     document = SSMDocument(
         schema_version="1.0",
         description="ssm document",
@@ -39,7 +57,7 @@ def test_aws_audit_ssm_document_compliance_false() -> None:
             "s3BucketName": "mdtp-ssm-session-manager-audit-logs",
             "s3KeyPrefix": "123456789012",
             "s3EncryptionEnabled": True,
-            "maxSessionDuration": "1440",
+            "maxSessionDuration": "90",
             "shellProfile": {
                 "linux": "cd ~ && /bin/bash && echo 'This session will be automatically terminated after 2 hours'"
             },
@@ -48,6 +66,124 @@ def test_aws_audit_ssm_document_compliance_false() -> None:
 
     ssm_client = Mock(get_document=Mock(return_value=document))
     task_report = AwsAuditSSMDocumentTask(account=account(), region=TEST_REGION)._run_task(ssm_client)
-    expected = {"documents": [{"name": "SSM-SessionManagerRunShell", "compliant": True}]}
 
-    assert expected != task_report
+    assert REPORT_FULL_COMPLIANCE == task_report
+
+
+def test_aws_audit_ssm_document_compliance_on_high_max_session_duration() -> None:
+    document = SSMDocument(
+        schema_version="1.0",
+        description="ssm document",
+        session_type="Standard_Stream",
+        inputs={
+            "s3BucketName": "mdtp-ssm-session-manager-audit-logs",
+            "s3KeyPrefix": "123456789012",
+            "s3EncryptionEnabled": True,
+            "maxSessionDuration": "121",
+            "shellProfile": {
+                "linux": "cd ~ && /bin/bash && echo 'This session will be automatically terminated after 2 hours'"
+            },
+        },
+    )
+    ssm_client = Mock(get_document=Mock(return_value=document))
+    task_report = AwsAuditSSMDocumentTask(account=account(), region=TEST_REGION)._run_task(ssm_client)
+    expected = {
+        "documents": [
+            {
+                "name": "SSM-SessionManagerRunShell",
+                "compliancy": {
+                    "s3BucketName": {
+                        "compliant": True,
+                        "message": "S3 bucket name should be mdtp-ssm-session-manager-audit-logs",
+                    },
+                    "s3EncryptionEnabled": {"compliant": True, "message": "S3 encryption should be enabled"},
+                    "maxSessionDuration": {
+                        "compliant": False,
+                        "message": "maxSessionDuration should be less than or equal to 120 mins",
+                    },
+                    "shellProfile": {"compliant": True, "message": "shellProfile should match expected config"},
+                },
+            }
+        ]
+    }
+
+    assert expected == task_report
+
+
+def test_aws_audit_ssm_document_compliance_on_s3_config_items() -> None:
+    document = SSMDocument(
+        schema_version="1.0",
+        description="ssm document",
+        session_type="Standard_Stream",
+        inputs={
+            "s3BucketName": "fake-ssm-session-manager-audit-logs",
+            "s3KeyPrefix": "123456789012",
+            "s3EncryptionEnabled": False,
+            "maxSessionDuration": "120",
+            "shellProfile": {
+                "linux": "cd ~ && /bin/bash && echo 'This session will be automatically terminated after 2 hours'"
+            },
+        },
+    )
+
+    ssm_client = Mock(get_document=Mock(return_value=document))
+    task_report = AwsAuditSSMDocumentTask(account=account(), region=TEST_REGION)._run_task(ssm_client)
+    expected = {
+        "documents": [
+            {
+                "name": "SSM-SessionManagerRunShell",
+                "compliancy": {
+                    "s3BucketName": {
+                        "compliant": False,
+                        "message": "S3 bucket name should be mdtp-ssm-session-manager-audit-logs",
+                    },
+                    "s3EncryptionEnabled": {"compliant": False, "message": "S3 encryption should be enabled"},
+                    "maxSessionDuration": {
+                        "compliant": True,
+                        "message": "maxSessionDuration should be less than or equal to 120 mins",
+                    },
+                    "shellProfile": {"compliant": True, "message": "shellProfile should match expected config"},
+                },
+            }
+        ]
+    }
+
+    assert expected == task_report
+
+
+def test_aws_audit_ssm_document_compliance_on_shell_profile() -> None:
+    document = SSMDocument(
+        schema_version="1.0",
+        description="ssm document",
+        session_type="Standard_Stream",
+        inputs={
+            "s3BucketName": "mdtp-ssm-session-manager-audit-logs",
+            "s3KeyPrefix": "123456789012",
+            "s3EncryptionEnabled": True,
+            "maxSessionDuration": "120",
+            "shellProfile": {"linux": "cd ~ && /bin/bash && echo 'Hello World!'"},
+        },
+    )
+    ssm_client = Mock(get_document=Mock(return_value=document))
+    task_report = AwsAuditSSMDocumentTask(account=account(), region=TEST_REGION)._run_task(ssm_client)
+    expected = {
+        "documents": [
+            {
+                "name": "SSM-SessionManagerRunShell",
+                "compliancy": {
+                    "s3BucketName": {
+                        "compliant": True,
+                        "message": "S3 bucket name should be mdtp-ssm-session-manager-audit-logs",
+                    },
+                    "s3EncryptionEnabled": {"compliant": True, "message": "S3 encryption should be enabled"},
+                    "maxSessionDuration": {
+                        "compliant": True,
+                        "message": "maxSessionDuration should be less than or equal to 120 mins",
+                    },
+                    "shellProfile": {"compliant": False, "message": "shellProfile should match expected config"},
+                },
+            }
+        ]
+    }
+
+    assert expected == task_report


### PR DESCRIPTION
Improve ssm document audit report

This change give more specific details about the non-compliant config item